### PR TITLE
fix operating systems stats table width

### DIFF
--- a/04_install-pep-talk.Rmd
+++ b/04_install-pep-talk.Rmd
@@ -15,10 +15,8 @@ In their defense, it's hard to write installation instructions. Failures can be 
 ## Success and operating systems
 
 <style type="text/css">
-.table {
-
-    width: 40%;
-
+#success-and-operating-systems table {
+  width: auto;
 }
 </style>
 


### PR DESCRIPTION
it looks like bookdown makes all tables 100% width by default so we need to have very specific CSS to target the table