### PR TITLE
Fix typo in GITHUB_PAT instructions

### DIFF
--- a/81_github-api-tokens.Rmd
+++ b/81_github-api-tokens.Rmd
@@ -49,7 +49,7 @@ normalizePath("~/")
 If you have no idea how to do any of this, here's one way from R:
 
 ```{r eval = FALSE}
-cat("8c70fd8419398999c9ac5bacf3192882193cadf2\n",
+cat("GITHUB_PAT=8c70fd8419398999c9ac5bacf3192882193cadf2\n",
     file = file.path(normalizePath("~/"), ".Renviron"), append = TRUE)
 ```
 


### PR DESCRIPTION
Somebody actually used this and discovered a pretty critical typo!