### PR TITLE
Update 07_install-git.Rmd

### DIFF
--- a/07_install-git.Rmd
+++ b/07_install-git.Rmd
@@ -32,6 +32,7 @@ Mac OS users might get an immediate offer to install command line developer tool
 
   * This approach leaves the Git executable in a conventional location, which will help you and other programs, e.g. RStudio, find it and use it. This also supports a transition to more expert use, because the Bash shell will be useful as you venture outside of R/RStudio.
   * This also leaves you with a Git client, though not a very good one. So check out Git clients we recommend (chapter \@ref(git-client)).
+  *RStudio for windows likes for git to be in the \Program Files(x86)\ folder. If not in this location, RStudio may not detect it, and may cause headaches for you later.
   
 **Option 2** (*NOT recommended*): The GitHub hosting site offers [GitHub Desktop for Windows](https://desktop.github.com/) that provides Git itself, a client, and smooth integration with GitHub.
 


### PR DESCRIPTION
 added note under installation for windows:
 *RStudio for windows likes for git to be in the \Program Files(x86)\ folder. If not in this location, RStudio may not detect it, and may cause headaches for you later.

This is not readily apparent - that I noticed- elsewhere in the instructions, and caused me quite the headache, that may or may not have lead to a LOT of stack overflow searches, finally finding the notes in chapter 14 *STILL* not catching the issue, tweeting @jennybryan with a steve carrell gif, and FINALLY figuring out what my issue was. Would like to save others this headache :)