### PR TITLE
link at l.124 not working

### DIFF
--- a/50_more-content.Rmd
+++ b/50_more-content.Rmd
@@ -121,7 +121,6 @@ Workflows for group of 1, 2, 5, 10
 
   * Fork and Pull vs Shared Repository
   
-    - <https://help.github.com/articles/types-of-collaborative-development-models/>
     - <https://help.github.com/articles/using-pull-requests/>
 
 ## How the square bracket links work

--- a/50_more-content.Rmd
+++ b/50_more-content.Rmd
@@ -121,6 +121,7 @@ Workflows for group of 1, 2, 5, 10
 
   * Fork and Pull vs Shared Repository
   
+    - <https://help.github.com/articles/about-collaborative-development-models/>
     - <https://help.github.com/articles/using-pull-requests/>
 
 ## How the square bracket links work


### PR DESCRIPTION
This url does not seem to be available anymore: https://help.github.com/articles/types-of-collaborative-development-models/