### PR TITLE
Update RawGit status

### DIFF
--- a/60_article-make-github-repo-browsable.Rmd
+++ b/60_article-make-github-repo-browsable.Rmd
@@ -118,16 +118,18 @@ If you have an HTML file in a GitHub repository, simply visiting the file shows 
 
   * <https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/master/bit003_api-key-env-var.html>
 
-No one wants to look at that. You can provide this URL to [rawgit.com](http://rawgit.com) to serve this HTML more properly and get a decent preview.
+No one wants to look at that. ~~You can provide this URL to [rawgit.com](http://rawgit.com) to serve this HTML more properly and get a decent preview.~~
 
-You can form two different types of URLs with [rawgit.com](http://rawgit.com):
+~~You can form two different types of URLs with [rawgit.com](http://rawgit.com):~~
 
-  * For sharing low-traffic, temporary examples or demos with small numbers of people, do this:
-    - <https://rawgit.com/STAT545-UBC/STAT545-UBC.github.io/master/bit003_api-key-env-var.html>
-    - Basically: replace `https://github.com/` with `https://rawgit.com/`
-  * For use on production websites with any amount of traffic, do this:
-    - <https://cdn.rawgit.com/STAT545-UBC/STAT545-UBC.github.io/master/bit003_api-key-env-var.html>
-    - Basically: replace `https://github.com/` with `https://cdn.rawgit.com/`
+  * ~~For sharing low-traffic, temporary examples or demos with small numbers of people, do this:~~
+    - ~~<https://rawgit.com/STAT545-UBC/STAT545-UBC.github.io/master/bit003_api-key-env-var.html>~~
+    - ~~Basically: replace `https://github.com/` with `https://rawgit.com/`~~
+  * ~~For use on production websites with any amount of traffic, do this:~~
+    - ~~<https://cdn.rawgit.com/STAT545-UBC/STAT545-UBC.github.io/master/bit003_api-key-env-var.html>~~
+    - ~~Basically: replace `https://github.com/` with `https://cdn.rawgit.com/`~~
+
+*2018-10-09 update: RawGit [announced](https://rawgit.com/) that it is in a sunset phase and will soon shut down. They recommended: [jsDelivr](https://www.jsdelivr.com/rawgit), [GitHub Pages](https://pages.github.com/), [CodeSandbox](https://codesandbox.io/), and [unpkg](https://unpkg.com/#/) as alternatives.*
     
 This sort of enhanced link might be one of the useful things to put in a `README.md` or other Markdown file in the repo.
 


### PR DESCRIPTION
* Update that RawGit is no-more in GH browsability chapter (same as https://github.com/STAT545-UBC/STAT545-UBC.github.io/pull/73).

* Note: I did _not_ rebuild the book, so this is just the Rmd.