### PR TITLE
Get rid of single and double quotes in the netlify message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - nvm install stable
   - npm install netlify-cli -g
   - export COMMIT_MSG=$(echo "$TRAVIS_COMMIT_MESSAGE" | head -n1)
+  - export COMMIT_MSG=${COMMIT_MSG//[\'\"]/}
   - export DEPLOY_MSG="${TRAVIS_COMMIT:0:7} ${COMMIT_MSG:0:50}"
 
 env:


### PR DESCRIPTION
Good grief this was aggravating! I concluded that eliminating quotes entirely was unfortunately the best option. Even when properly escaped, `netlify deploy` barfed on unbalanced quotes, i.e if taking the first 50 characters retained only the opening quote (which doesn't seem correct, but is also not worth worrying about).

I think we want: take the first line of the commit message, get rid of tricky characters, truncate.

I would appreciate any clean up that screams out at you.

Resources consulted:

https://www.tldp.org/LDP/abs/html/string-manipulation.html

https://unix.stackexchange.com/questions/379181/escape-a-variable-for-use-as-content-of-another-script

This sounds perfect:

```
${parameter@operator}
The expansion is either a transformation of the value of parameter or information about parameter itself, depending on the value of operator. Each operator is a single letter:

Q
The expansion is a string that is the value of parameter quoted in a format that can be reused as input.
```

but neither my bash nor that on travis appears to be recent enough to support it. And the possible misbehaviour of `netlify deploy` would still apply.