### PR TITLE
Remove a challenging character from search links

### DIFF
--- a/git-remotes.Rmd
+++ b/git-remotes.Rmd
@@ -9,7 +9,7 @@ remotes. You pull others changes from remotes and push your changes to remotes.
 `git remote` lists the names of available remotes, but usually it is more
 useful to see what URLs each note corresponds to (with `-v`).
 
-```{bash}
+```shell
 git remote -v
 ```
 

--- a/notes-ideas.Rmd
+++ b/notes-ideas.Rmd
@@ -81,7 +81,6 @@ Browsing
 Searching
 
   * My gist, re: the cran user: <https://gist.github.com/jennybc/4a1bf4e9e1bb3a0a9b56>
-  * Recent search for roxygen template usage in the wild: <https://github.com/search?utf8=✓&q=man-roxygen+in:path&type=Code&ref=searchresults>
 
 Being a useful useR
 

--- a/prompt-search-github.Rmd
+++ b/prompt-search-github.Rmd
@@ -28,7 +28,7 @@ What if a function in a package has no examples? Or is poorly exampled? Wouldn't
 "llply" user:cran language:R
 ```
 
-Or just [click here](https://github.com/search?l=r&q=%22llply%22+user%3Acran+language%3AR&ref=searchresults&type=Code&utf8=✓).
+Or just [click here](https://github.com/search?l=r&q=%22llply%22+user%3Acran+language%3AR&ref=searchresults&type=Code).
 
 Another example that recently came up on r-package-devel:
 
@@ -36,4 +36,4 @@ How to see lots of examples of roxygen templates?
 
 This search finds >1400 examples of roxygen templates in the wild:
 
-<https://github.com/search?utf8=✓&q=man-roxygen+in%3Apath&type=Code&ref=searchresults>
+<https://github.com/search?q=man-roxygen+in%3Apath&type=Code&ref=searchresults>


### PR DESCRIPTION
Fixes #117, in which it appears these links cause problems rendering the book to PDF