### PR TITLE
Update GitHub Desktop Git client description

### DIFF
--- a/install-git-client.Rmd
+++ b/install-git-client.Rmd
@@ -46,9 +46,9 @@ If your Git life happens on your own computer, there is no reason to deny yourse
 
   * [GitKraken](https://www.gitkraken.com), which is also free, arrived on the scene more recently. It's exciting because it works across all three OSes our students use: Windows, macOS, and Linux. I hear very good reviews, especially from long-suffering Linux users who haven't had any great options until now.
 
+  * GitHub offers a free Git(Hub) client, [GitHub Desktop](https://desktop.github.com/), for Windows and macOS. Although we previously discouraged its use, GitHub's client has since gotten a thorough makeover that eliminates several of our concerns, so we're cautiously optimistic. GitHub Desktop is aimed at beginners who want the most useful features of Git front and center. The flipside is that it may not support some of the more advanced workflows exposed by the clients above. If you choose GitHub Desktop and it works well for you, we'd love to hear more in an issue, so we can continue to refine this recommendation.
+
   * [GitUp](https://gitup.co) is a free, open source client for macOS. I've heard good things about it and like what I read on the website. However, I tried to make myself use it for a day and went sort of nuts, possibly because I'm so used to SourceTree. YMMV.
-  
-  * GitHub offers a free Git(Hub) client, [GitHub Desktop](https://desktop.github.com/), for Windows and macOS. It's great for beginners and puts the most useful features of Git front and center so you don't get bogged down in the complexity of rarely used Git functionality.
 
   * Others that I have heard positive reviews for:
   

--- a/install-git-client.Rmd
+++ b/install-git-client.Rmd
@@ -48,11 +48,7 @@ If your Git life happens on your own computer, there is no reason to deny yourse
 
   * [GitUp](https://gitup.co) is a free, open source client for macOS. I've heard good things about it and like what I read on the website. However, I tried to make myself use it for a day and went sort of nuts, possibly because I'm so used to SourceTree. YMMV.
   
-  * GitHub also offers [a free Git(Hub) client](https://desktop.github.com/) for Windows and macOS. We do NOT recommend it for Windows and have serious reservations even for macOS. What do we object to?
-    - The degree of hand-holding offered by GitHub's clients borders on hand-*cuffs*.
-    - The Windows client sometimes leaves the Git executable so well hidden that we can't find it. This is a deal-killer, because that means RStudio can't find it either.
-    - These clients wrap Git functionality so thoroughly that we've had students make some destructive mistakes. For example, we've seen a "sync" operation that resulted in the loss of local uncommitted changes. Exactly which Git operations, in what order, are implied by "sync", is [not entirely clear](http://stackoverflow.com/questions/12104513/what-does-github-for-windows-sync-do). We prefer clients that expose Git more explicitly.
-    - We've heard similar negative reviews from other instructors. It's not just us.
+  * GitHub offers a free Git(Hub) client, [GitHub Desktop](https://desktop.github.com/), for Windows and macOS. It's great for beginners and puts the most useful features of Git front and center so you don't get bogged down in the complexity of rarely used Git functionality.
 
   * Others that I have heard positive reviews for:
   

--- a/install-git.Rmd
+++ b/install-git.Rmd
@@ -57,10 +57,6 @@ This installs the most current [Git (Install) X.Y.Z](https://chocolatey.org/pack
 
 If you [search Chocolatey packages](https://chocolatey.org/packages) yourself, you might see two packages that install Git -- "Git (Install) 2.20.1" and "Git 2.20.1", at the time of writing. I believe "Git (Install) 2.20.1" is technically the more correct, but I also think it doesn't really matter which one you use. A rather confusing explanation is found [here](https://chocolatey.org/faq#what-is-the-difference-between-packages-no-suffix-as-compared-to-install-portable). Don't worry too much about whether you do `choco install git.install` or `choco install git`.
   
-**Option 3** (*NOT recommended*): The GitHub hosting site offers [GitHub Desktop for Windows](https://desktop.github.com/) that provides Git itself, a client, and smooth integration with GitHub.
-
-  * [Their Windows set-up instructions](https://help.github.com/articles/set-up-git#platform-windows) recommend this method of Git installation.
-  * Why don't we like it? We've seen GitHub Desktop for Windows lead to Git installation in suboptimal locations, such as `~/AppData/Local`, and in other places we could never find. If you were __only__ going to interact with GitHub via this app, maybe that's OK, but that does not apply to you. We are also not very fond of the GitHub Desktop client for using using Git and prefer other clients. Therefore, we strongly recommend options 1 and 2 instead.
 
 ## macOS
 
@@ -97,10 +93,6 @@ Note also that, after upgrading macOS, you might need to re-do the above and/or 
 brew install git
 ```
 
-**Option 4** (*NOT recommended*): The GitHub hosting site offers [GitHub Desktop for Mac](https://desktop.github.com/) that provides *the option* to install Git itself, a client, and smooth integration with GitHub..
-
-  * [Their macOS set-up instructions](https://help.github.com/articles/set-up-git#platform-mac) recommend this method of Git installation.
-  * We don't like GitHub Desktop as a Git client, so this is a very cumbersome way to install Git. Consider this option a last resort.
 
 ## Linux
 


### PR DESCRIPTION
Closes #136 

This updates the description of GitHub Desktop to remove the portion that referred to the old version of the app, along with a value proposition for people likely using this guide. 😄 