### PR TITLE
Use create_project instead of use_rstudio

### DIFF
--- a/usage-existing-project-github-last.Rmd
+++ b/usage-existing-project-github-last.Rmd
@@ -12,7 +12,7 @@ We assume you've got your existing R project isolated in a directory on your com
 
 If it's not already an RStudio Project, make it so:
 
-  * If you use the [usethis](https://cran.r-project.org/package=usethis) package, set the existing directory as the current project with `proj_set()`, then do `usethis::use_rstudio()`.
+  * If you use the [usethis](https://cran.r-project.org/package=usethis) package, set the existing directory as the current project with `usethis::create_project()`.
   * Within RStudio you can do: *File > New Project > Existing Directory* and, if you wish, "Open in new session".
 
 If your project is already an RStudio Project, launch it.


### PR DESCRIPTION
Changed "set the existing directory as the current project with proj_set(), then do usethis::use_rstudio()" to "usethis::create_project()" as use_rstudio is mainly intended for internal use.