### PR TITLE
Add GitHub PAT to workshop setup instructions

### DIFF
--- a/workshops.Rmd
+++ b/workshops.Rmd
@@ -20,6 +20,7 @@ Try this. Best case scenario is about 1 - 2 hours. If you hit a wall, we will he
   * [Introduce yourself to Git](#hello-git).
   * [Prove local Git can talk to GitHub](#push-pull-github).
   * [Cache your username and password](#credential-caching) or [set up SSH keys](#ssh-keys) so you don't need to authenticate yourself to GitHub interactively *ad nauseum*.
+  * [Create and save a GitHub Personal Access Token (PAT)](#github-pat).
   * [Prove RStudio can find local Git](#rstudio-git-github) and, therefore, can talk to GitHub.
     - FYI: this is where our hands-on activities usually start. We walk through a similar activity together, with narrative, and build from there.
   * Contemplate if you'd like to [install an optional Git client](#git-client), now or in future.


### PR DESCRIPTION
As we talked about last week, I've added the Github PAT stuff to the workshop setup instructions. This section is still currently in the appendix, I wasn't sure if you wanted to move it somewhere more central. Maybe it should go in "II Connect Git, GitHub, RStudio"? Let me know what you think and I can make changes to this PR.