### PR TITLE
Update section 17.5.4 in line with github guidance

### DIFF
--- a/usage-existing-project-github-last.Rmd
+++ b/usage-existing-project-github-last.Rmd
@@ -84,9 +84,13 @@ In a shell, do this, substituting your URL:
 
         git remote add origin https://github.com/jennybc/myrepo.git
 
-Push and cement the tracking relationship between your local `master` branch and `master` on GitHub:
+Renamimng your current branch to `main`: 
+
+        git branch -M main
+
+Pushing and cementing the tracking relationship between your local `main` branch and `main` on GitHub:
   
-        git push --set-upstream origin master
+        git push -u origin main
 
 ## Confirm the local files propagated to the GitHub remote
 


### PR DESCRIPTION
Attempting to run 'git push --set-upstream origin master' now generates a 'failed to push some refs to upstream' error message. Github also defaults to the branch name 'main' rather than 'master' (https://github.com/github/renaming). Current github guidance on pushing existing repositories (see quick setup page when creating repo on github) is to use the command sequence 

git remote add origin https://github.com/blahblahblah
git branch -M main
git push -u origin main