### PR TITLE
Update workflows-upstream-changes-into-fork.Rmd

### DIFF
--- a/workflows-upstream-changes-into-fork.Rmd
+++ b/workflows-upstream-changes-into-fork.Rmd
@@ -48,7 +48,15 @@ origin  https://github.com/YOU/REPO.git (push)
 
 There is only one remote, named `origin`, corresponding to your fork on GitHub. This figure depicts a BEFORE scenario:
 
-![](img/fork-no-upstream-sad.png)
+
+```{r fork-no-upstream-sad, eval=TRUE, echo=FALSE, dpi=1}
+#| fig.cap: > 
+#|   Before scenario: there is no direct connection between `OWNER/REPO` and your local copy of the repo.
+#| fig.alt: > 
+#|    Quadrant diagram with yellow cylinder indicating Them in top left, red cylinder indicating You and origin in top right, red cylinder 
+#|    indicating main repo in the bottom right, and no possible connection between top left and bottom right with a crying emoji.
+knitr::include_graphics("img/fork-no-upstream-sad.png")
+```
 
 This is sad, because there is no direct connection between `OWNER/REPO` and your local copy of the repo.
 


### PR DESCRIPTION
Hi wonderful Happy Git with R maintainers!  I was recently reading Ch 31:  Get upstream changes for a fork, and the images were hard to digest because they were in a very large size with a scroll bar.  This might be improved by utilizing `knitr::include_graphics` instead, which I believe should automatically resize the image to 100%. of the screen width.  In  addition, with this function you can also add figure captions and alt text, which can be useful for those who use screen reading assistive technology. I used the chunk option `dpi=1` because that is what was playing well with my blog posts, but I am not sure if that is necessary (or works) for your set up.

I didn't think too deeply about the caption or alt text, and I only submitted this for a single figure so far.  But if you confirm that (1) you want to proceed and (2) this chunk works for this book . I am happy to help or draft the captioning and alt text for the remaining figures in this chapter.