### PR TITLE
Minor suggestion for connect-https-pat.Rmd to allow easy copy/paste of gitcreds_set()

### DIFF
--- a/connect-https-pat.Rmd
+++ b/connect-https-pat.Rmd
@@ -53,9 +53,13 @@ GitHub no longer allows passwords in this context, but most basic Git tools stil
 You could even get out ahead of this and store the PAT explicitly right now.
 In R, call `gitcreds::gitcreds_set()` to get a prompt where you can paste your PAT:
 
-```{sh eval = FALSE}
-> gitcreds::gitcreds_set()
+```{r eval = FALSE}
+gitcreds::gitcreds_set()
+```
 
+Paste the PAT in response to the dialogue in the console:
+
+```
 ? Enter password or token: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 -> Adding new credentials...
 -> Removing credentials from cache...


### PR DESCRIPTION
Hi - I am so thankful for this resource. 

A minor suggestion, which is to change the gitcreds::gitcreds_set() code in chapter 9 so that it can actually be copied straight into R. As of right now, the function and resulting dialogue is copied, which is a bit annoying if you're trying to paste into the R console. Please feel free to decline.