### PR TITLE
git config commands need double quotes instead of single quotes

### DIFF
--- a/install-introduce-self-git.Rmd
+++ b/install-introduce-self-git.Rmd
@@ -3,8 +3,8 @@
 In the shell (Appendix \@ref(shell)):
 
 ``` bash
-git config --global user.name 'Jane Doe'
-git config --global user.email 'jane@example.com'
+git config --global user.name "Jane Doe"
+git config --global user.email "jane@example.com"
 git config --global --list
 ```
 


### PR DESCRIPTION
You might want to test this on other devices/OSs, and if this doesn't work across the board then there should be a note that different quotes are needed based on your OS.

I'm on a freshly reformatted Windows 10 Pro, using the classic Windows Command Prompt, and I noticed that when using single quotes, the value gets cut off at whitespace:

```cmd
C:\Users\Dean>git config --global user.name 'Jane Doe'

C:\Users\Dean>git config --global --list
user.name='Jane

C:\Users\Dean>git config --global --unset-all user.name

C:\Users\Dean>git config --global user.name "Jane Doe"

C:\Users\Dean>git config --global --list
user.name=Jane Doe
```