### PR TITLE
Image render fix for chapters 25, 26, and 32

### DIFF
--- a/remote-setups-common.Rmd
+++ b/remote-setups-common.Rmd
@@ -18,7 +18,7 @@ As a starting point, consider a local Git repo that is not yet connected to GitH
 
 ```{r no_github}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'no_github\'"
+#| fig.alt = "Setup described as 'no_github'"
 
 knitr::include_graphics("img/no-github.jpeg")
 
@@ -45,7 +45,7 @@ A common next step is to associate a local repo with a copy on GitHub, owned by 
 
 ```{r ours-you}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'ours\'"
+#| fig.alt = "Setup described as 'ours'"
 knitr::include_graphics("img/ours-you.jpeg")
 ```
 
@@ -89,7 +89,7 @@ Here is a variation on "ours" that is equivalent in practice.
 
 ```{r ours-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'ours\'"
+#| fig.alt = "Setup described as 'ours'"
 knitr::include_graphics("img/ours-them.jpeg")
 ```
 
@@ -115,7 +115,7 @@ It's not broken *per se*, but it's limiting.
 
 ```{r theirs}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'theirs\'"
+#| fig.alt = "Setup described as 'theirs'"
 knitr::include_graphics("img/theirs.jpeg")
 ```
 
@@ -146,7 +146,7 @@ This is an ideal setup if you want to make a pull request and generally follow t
 
 ```{r fork-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'fork\'"
+#| fig.alt = "Setup described as 'fork'"
 knitr::include_graphics("img/fork-them.jpeg")
 ```
 
@@ -188,7 +188,7 @@ This is a less common variation on the fork setup.
 
 ```{r fork-ours}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'fork\'"
+#| fig.alt = "Setup described as 'fork'"
 knitr::include_graphics("img/fork-ours.jpeg")
 ```
 
@@ -210,7 +210,7 @@ Here is one last fork setup that's sub-optimal, but it can be salvaged.
 
 ```{r fork-no-upstream}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'fork_upstream_is_not_origin_parent\'"
+#| fig.alt = "Setup described as 'fork_upstream_is_not_origin_parent'"
 knitr::include_graphics("img/fork_upstream_is_not_origin_parent.jpeg")
 ```
 

--- a/remote-setups-common.Rmd
+++ b/remote-setups-common.Rmd
@@ -45,7 +45,7 @@ A common next step is to associate a local repo with a copy on GitHub, owned by 
 
 ```{r ours-you}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"ours\""
+#| fig.alt = "Setup described as \'ours\'"
 knitr::include_graphics("img/ours-you.jpeg")
 ```
 
@@ -89,7 +89,7 @@ Here is a variation on "ours" that is equivalent in practice.
 
 ```{r ours-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"ours\""
+#| fig.alt = "Setup described as \'ours\'"
 knitr::include_graphics("img/ours-them.jpeg")
 ```
 
@@ -115,7 +115,7 @@ It's not broken *per se*, but it's limiting.
 
 ```{r theirs}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"theirs\""
+#| fig.alt = "Setup described as \'theirs\'"
 knitr::include_graphics("img/theirs.jpeg")
 ```
 
@@ -146,7 +146,7 @@ This is an ideal setup if you want to make a pull request and generally follow t
 
 ```{r fork-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"fork\""
+#| fig.alt = "Setup described as \'fork\'"
 knitr::include_graphics("img/fork-them.jpeg")
 ```
 
@@ -188,7 +188,7 @@ This is a less common variation on the fork setup.
 
 ```{r fork-ours}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"fork\""
+#| fig.alt = "Setup described as \'fork\'"
 knitr::include_graphics("img/fork-ours.jpeg")
 ```
 
@@ -210,7 +210,7 @@ Here is one last fork setup that's sub-optimal, but it can be salvaged.
 
 ```{r fork-no-upstream}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"fork_upstream_is_not_origin_parent\""
+#| fig.alt = "Setup described as \'fork_upstream_is_not_origin_parent\'"
 knitr::include_graphics("img/fork_upstream_is_not_origin_parent.jpeg")
 ```
 

--- a/remote-setups-common.Rmd
+++ b/remote-setups-common.Rmd
@@ -18,8 +18,10 @@ As a starting point, consider a local Git repo that is not yet connected to GitH
 
 ```{r no_github}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"no_github\""
+#| fig.alt = "Setup described as \'no_github\'"
+
 knitr::include_graphics("img/no-github.jpeg")
+
 ```
 
 This is not very exciting, but sets the stage for what's to come.

--- a/remote-setups-equivocal.Rmd
+++ b/remote-setups-equivocal.Rmd
@@ -33,7 +33,7 @@ When we detect just one GitHub remote, but we can't verify the info above, useth
 
 ```{r maybe_ours_or_theirs}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"maybe_ours_or_theirs\""
+#| fig.alt = "Setup described as \'maybe_ours_or_theirs\'"
 knitr::include_graphics("img/maybe_ours_or_theirs.jpeg")
 ```
 
@@ -45,7 +45,7 @@ When we detect two GitHub remotes, but we can't verify the info above, usethis d
 
 ```{r maybe_fork}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"maybe_fork\""
+#| fig.alt = "Setup described as \'maybe_fork\'"
 knitr::include_graphics("img/maybe_fork.jpeg")
 ```
 

--- a/remote-setups-equivocal.Rmd
+++ b/remote-setups-equivocal.Rmd
@@ -33,7 +33,7 @@ When we detect just one GitHub remote, but we can't verify the info above, useth
 
 ```{r maybe_ours_or_theirs}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'maybe_ours_or_theirs\'"
+#| fig.alt = "Setup described as 'maybe_ours_or_theirs'"
 knitr::include_graphics("img/maybe_ours_or_theirs.jpeg")
 ```
 
@@ -45,7 +45,7 @@ When we detect two GitHub remotes, but we can't verify the info above, usethis d
 
 ```{r maybe_fork}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'maybe_fork\'"
+#| fig.alt = "Setup described as 'maybe_fork'"
 knitr::include_graphics("img/maybe_fork.jpeg")
 ```
 

--- a/render-r-script-demo.md
+++ b/render-r-script-demo.md
@@ -1,7 +1,7 @@
 R scripts can be rendered!
 ================
-jenny
-2022-06-23
+jeremyallen
+2023-10-14
 
 Here’s some prose in a very special comment. Let’s summarize the
 built-in dataset `VADeaths`.

--- a/workflows-upstream-changes-into-fork.Rmd
+++ b/workflows-upstream-changes-into-fork.Rmd
@@ -80,7 +80,7 @@ We assume your repo has this favorable configuration:
 
 ```{r fork-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \"fork\""
+#| fig.alt = "Setup described as \'fork\'"
 knitr::include_graphics("img/fork-them.jpeg")
 ```
 

--- a/workflows-upstream-changes-into-fork.Rmd
+++ b/workflows-upstream-changes-into-fork.Rmd
@@ -80,7 +80,7 @@ We assume your repo has this favorable configuration:
 
 ```{r fork-them}
 #| echo = FALSE, fig.align = "center", out.width = "60%",
-#| fig.alt = "Setup described as \'fork\'"
+#| fig.alt = "Setup described as 'fork'"
 knitr::include_graphics("img/fork-them.jpeg")
 ```
 


### PR DESCRIPTION
Hi Jenny! Love this book so much and use it more frequently these days.

I noticed images not rendering in these chapters. Html was in their place. The culprit seems to be nested double quotes in the fig.alt chunk options. I changed those to single quotes. The images now render when I  build.